### PR TITLE
dropping http from urls so that https works

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 	<head>
 		<title>Box Model Demo</title>
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 		<link rel="stylesheet" href="box-model.css">
 	</head>
 	<body>
@@ -119,7 +119,7 @@
 			</form>
 		</aside>
 
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" ></script>
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" ></script>
 		<script src="box-model.js"></script>
 		<script>
 			// Twitter widgets


### PR DESCRIPTION
Hi @guyroutledge,

I noticed when viewing your box model demo that it fails in my browser (Firefox Developer Edition with HTTPS Everywhere, also happened in latest Chrome) which forces HTTPS where it can.

This PR fixes the issue (compare https://rjkerrison.co.uk/box-model/ and https://guyroutledge.github.io/box-model/)